### PR TITLE
do not use ndk app yml as a direct bind

### DIFF
--- a/.gen/dev.clab.yml.tpl
+++ b/.gen/dev.clab.yml.tpl
@@ -3,20 +3,20 @@ name: "{{ getenv "APPNAME" }}-dev"
 topology:
   defaults:
     kind: srl
-    image: ghcr.io/nokia/srlinux:21.6.4
+    image: ghcr.io/nokia/srlinux:22.6.1
 
   nodes:
     srl1:
       binds:
         - "../build:/tmp/build" # mount dir with binaries
         - "../logs/srl1:/var/log/srlinux" # expose srlinux logs to a dev machine
-        - "../{{ getenv "APPNAME" }}.yml:/etc/opt/srlinux/appmgr/{{ getenv "APPNAME" }}.yml" # put agent config file to appmgr directory
+        - "../{{ getenv "APPNAME" }}.yml:/tmp/{{ getenv "APPNAME" }}.yml" # put agent config file to temp dir. It will be copied to appmgr during lab postdeployment
         - "../yang:/opt/{{ getenv "APPNAME" }}/yang" # yang modules
     srl2:
       binds:
         - "../build:/tmp/build" # mount dir with binaries
         - "../logs/srl2:/var/log/srlinux" # expose srlinux logs to a dev machine
-        - "../{{ getenv "APPNAME" }}.yml:/etc/opt/srlinux/appmgr/{{ getenv "APPNAME" }}.yml" # put agent config file to appmgr directory
+        - "../{{ getenv "APPNAME" }}.yml:/tmp/{{ getenv "APPNAME" }}.yml" # put agent config file to temp dir. It will be copied to appmgr during lab postdeployment
         - "../yang:/opt/{{ getenv "APPNAME" }}/yang" # yang modules
   links:
     - endpoints:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ deploy-lab:
 	cd lab; \
 	sudo clab dep -t $(LABFILE)
 
-redeploy-lab: destroy-lab deploy-lab create-app-symlink
+redeploy-lab: destroy-lab deploy-lab create-app-symlink reload-app_mgr
 
 deploy-all: redeploy-all
 
@@ -78,7 +78,7 @@ restart-app:
 
 create-app-symlink:
 	cd lab; \
-	sudo clab exec -t $(LABFILE) --label clab-node-kind=srl --cmd 'sudo ln -s /tmp/build/$(APPNAME) /usr/local/bin/$(APPNAME)'
+	sudo clab exec -t $(LABFILE) --label clab-node-kind=srl --cmd 'sudo bash -c "ln -s /tmp/build/$(APPNAME) /usr/local/bin/$(APPNAME) && mkdir -p /etc/opt/srlinux/appmgr && cp /tmp/$(APPNAME).yml /etc/opt/srlinux/appmgr/$(APPNAME).yml"'
 
 compress-bin:
 	rm -f build/compressed


### PR DESCRIPTION
mounting app yaml directly before boot while binary is not yet available can cause agent to get stuck.
this PR adds the agent yaml symlink after the node starts and after the binary symlink is created